### PR TITLE
add docs links

### DIFF
--- a/unicorn.md
+++ b/unicorn.md
@@ -77,12 +77,17 @@
 ## Node.js and Express
   * [Node School](https//www.nodeschool.io)
   * [Express.js Docs](http://www.expressjs.com)
+  * [Node.js Docs](https://nodejs.org/en/docs/)
 
 ## Ruby & Ruby on Rails
   * [Why's Poignant Guide to Ruby](http://www.poignant.guide)
   * [Ruby on Rails Tutorial 3rd Edition](https://www.railstutorial.org) by Michael Hartl
   * [12 in 12 Challenge](https://www.mackenziechild.me/12-in-12/) by Mckenzie Child
-
+  * [Ruby Docs via Ruby-Doc](http://ruby-doc.org/)
+  * [Ruby on Rails Guides](http://guides.rubyonrails.org/)
+  
 ## PHP and Laravel
   * [Zend's PHP 101](http://www.devzone.zend.com/6/php-101-php-for-the-absolute-beginner/)
   * [Laracasts](https://www.laracasts.com/) by Jeffrey Way
+  * [PHP Docs](http://php.net/docs.php)
+  * [Laravel Docs](https://laravel.com/docs/5.5)

--- a/unicorn.md
+++ b/unicorn.md
@@ -43,12 +43,15 @@
   * [HTML5 Weekly newsletter](http://www.html5weekly.com)
   * [CSS Weekly](http://www.css-weekly.com) newsletter
   * [Responsive Design Weekly](http://www.responsivedesignweekly.com)
+  * [Mozilla Developer Network - HTML Docs](https://developer.mozilla.org/en-US/docs/Web/HTML)
+  * [Mozilla Developer Network - CSS Docs](https://developer.mozilla.org/en-US/docs/Web/CSS)
 
 ## JS
   * [Javascript for Cats](http://www.jsforcats.com) by Maxwell Ogden
   * [Eloquent Javascript](http://www.eloquentjavascript.net) by Marijn Haverbeke
   * [You Don't Know JS series](https://www.github.com/getify/You-Dont-Know-JS) by Kyle Simpson
   * [Understanding ECMAScript 6](https://leanpub.com/understandinges6/read) by Nicholas C. Zakas
+  * [Mozilla Developer Network - Javascript Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 
 ## Jekyll
   * [Jekyll Docs](https://www.jekyllrb.com)


### PR DESCRIPTION
First commit - In addition to mentioning MDN in the other essential resources section, I added the links for MDN's docs of HTML, CSS, and JS

Second commit - docs links are available for the listed backend languages. I was tempted to just flippantly link to DevDocs (which contains docs for pretty much any popular language/framework/library/tool, but it's better to be explicit.